### PR TITLE
Add different methods for handling blank GEOL_GEOL

### DIFF
--- a/AGS_Adapter/AGS_Adapter.csproj
+++ b/AGS_Adapter/AGS_Adapter.csproj
@@ -10,7 +10,7 @@
     <Authors>BHoM</Authors>
     <Copyright>Copyright � https://github.com/BHoM</Copyright>
     <RootNamespace>BH.Adapter.AGS</RootNamespace>
-    <FileVersion>7.0.0.0</FileVersion>
+    <FileVersion>7.2.0.0</FileVersion>
 	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/AGS_Adapter/AGS_Adapter.csproj
+++ b/AGS_Adapter/AGS_Adapter.csproj
@@ -10,7 +10,7 @@
     <Authors>BHoM</Authors>
     <Copyright>Copyright � https://github.com/BHoM</Copyright>
     <RootNamespace>BH.Adapter.AGS</RootNamespace>
-    <FileVersion>7.2.0.0</FileVersion>
+    <FileVersion>7.3.0.0</FileVersion>
 	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/AGS_Adapter/Convert/FromAGS/Stratum.cs
+++ b/AGS_Adapter/Convert/FromAGS/Stratum.cs
@@ -26,6 +26,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Ground;
+using BH.oM.Adapters.AGS;
+using System.Runtime.CompilerServices;
 
 namespace BH.Adapter.AGS
 {
@@ -34,7 +36,7 @@ namespace BH.Adapter.AGS
         /***************************************************/
         /**** Public Methods                            ****/
         /***************************************************/
-        public static Stratum FromStratum(Dictionary<string, string> data, Dictionary<string, string> units, string blankGeology)
+        public static Stratum FromStratum(Dictionary<string, string> data, Dictionary<string, string> units, string blankGeology, BlankGeologyStrategy blankGeologyStrategy)
         {
             string id = GetString(data, "LOCA_ID");
 
@@ -50,10 +52,6 @@ namespace BH.Adapter.AGS
                 return null;
             }
 
-            string observedGeology = GetString(data, "GEOL_GEOL");
-            if (observedGeology == "")
-                observedGeology = blankGeology;
-
             string interpretedGeology = GetString(data, "GEOL_GEO2");
             string legend = GetString(data, "GEOL_LEG");
             if (legend == "")
@@ -67,9 +65,49 @@ namespace BH.Adapter.AGS
             string references = GetString(data, "FILE_FSET");
             string remarks = GetString(data, "GEOL_REM");
 
+
             StratumReference reference = new StratumReference() { Remarks = remarks, LexiconCode = lexiconCode, Name = strataRef, Files = references };
             if (reference != null)
                 stratumProperties.Add(reference);
+
+            string observedGeology = GetString(data, "GEOL_GEOL");
+            if (observedGeology == "")
+            {
+                switch (blankGeologyStrategy)
+                {
+                    case BlankGeologyStrategy.Replace:
+                        {
+                            observedGeology = blankGeology;
+                            break;
+                        }
+                    case BlankGeologyStrategy.Legend:
+                        {
+                            if(legend != "")
+                                blankGeology = legend;
+                            break;
+                        }
+                    case BlankGeologyStrategy.Lexicon:
+                        {
+                            if (lexiconCode != "")
+                                blankGeology = lexiconCode;
+                            else
+                                Engine.Base.Compute.RecordWarning($"No Lexicon Code provided for {id}. Therefore, the blank geology cannot be set.");
+                            break;
+                        }
+                    case BlankGeologyStrategy.Description:
+                        {
+                            if (description != "")
+                            {
+                                string upperWords = String.Join(" ",description.Split(' ').Where(x => string.Equals(x, x.ToUpper(),StringComparison.Ordinal)));
+                                blankGeology = upperWords;
+                            }
+                            else
+                                Engine.Base.Compute.RecordWarning($"No description provided for {id}. Therefore, the blank geology cannot be set.");
+                            break;
+                        }
+
+                }
+            }
 
             Stratum strata = Engine.Ground.Create.Stratum(id, top, bottom, description, legend, observedGeology, interpretedGeology, "", blankGeology, stratumProperties);
 

--- a/AGS_Adapter/Convert/FromAGS/Stratum.cs
+++ b/AGS_Adapter/Convert/FromAGS/Stratum.cs
@@ -27,7 +27,6 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Ground;
 using BH.oM.Adapters.AGS;
-using System.Runtime.CompilerServices;
 
 namespace BH.Adapter.AGS
 {
@@ -83,13 +82,13 @@ namespace BH.Adapter.AGS
                     case BlankGeologyStrategy.Legend:
                         {
                             if(legend != "")
-                                blankGeology = legend;
+                                observedGeology = legend;
                             break;
                         }
                     case BlankGeologyStrategy.Lexicon:
                         {
                             if (lexiconCode != "")
-                                blankGeology = lexiconCode;
+                                observedGeology = lexiconCode;
                             else
                                 Engine.Base.Compute.RecordWarning($"No Lexicon Code provided for {id}. Therefore, the blank geology cannot be set.");
                             break;
@@ -98,8 +97,11 @@ namespace BH.Adapter.AGS
                         {
                             if (description != "")
                             {
-                                string upperWords = String.Join(" ",description.Split(' ').Where(x => string.Equals(x, x.ToUpper(),StringComparison.Ordinal)));
-                                blankGeology = upperWords;
+                                // keep only letters
+                                //Remove punctuation and numbers
+                                string upperWords = String.Join(" ", description.Split(' ').Where(x => string.Equals(x, x.ToUpper(), StringComparison.Ordinal)));
+                                upperWords = string.Concat(upperWords.Where(char.IsLetter));
+                                blankGeology = upperWords.Trim();
                             }
                             else
                                 Engine.Base.Compute.RecordWarning($"No description provided for {id}. Therefore, the blank geology cannot be set.");

--- a/AGS_Adapter/Convert/FromAGS/Stratum.cs
+++ b/AGS_Adapter/Convert/FromAGS/Stratum.cs
@@ -60,7 +60,7 @@ namespace BH.Adapter.AGS
             List<IStratumProperty> stratumProperties = new List<IStratumProperty>();
 
             string strataRef = GetString(data, "GEOL_STAT");
-            string lexiconCode = GetString(data, "GEOL_STAT");
+            string lexiconCode = GetString(data, "GEOL_BGS");
             string references = GetString(data, "FILE_FSET");
             string remarks = GetString(data, "GEOL_REM");
 
@@ -111,7 +111,7 @@ namespace BH.Adapter.AGS
                 }
             }
 
-            Stratum strata = Engine.Ground.Create.Stratum(id, top, bottom, description, legend, observedGeology, interpretedGeology, "", blankGeology, stratumProperties);
+            Stratum strata = Engine.Ground.Create.Stratum(id, top, bottom, description, legend, observedGeology, interpretedGeology, "", stratumProperties);
 
             strata.Name = strataRef;
 

--- a/AGS_Engine/AGS_Engine.csproj
+++ b/AGS_Engine/AGS_Engine.csproj
@@ -9,7 +9,7 @@
     <Authors>BHoM</Authors>
     <Copyright>Copyright © https://github.com/BHoM</Copyright>
     <RootNamespace>BH.Engine.Adapters.AGS</RootNamespace>
-    <FileVersion>7.2.0.0</FileVersion>
+    <FileVersion>7.3.0.0</FileVersion>
 	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/AGS_Engine/AGS_Engine.csproj
+++ b/AGS_Engine/AGS_Engine.csproj
@@ -9,7 +9,7 @@
     <Authors>BHoM</Authors>
     <Copyright>Copyright © https://github.com/BHoM</Copyright>
     <RootNamespace>BH.Engine.Adapters.AGS</RootNamespace>
-    <FileVersion>7.0.0.0</FileVersion>
+    <FileVersion>7.2.0.0</FileVersion>
 	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/AGS_oM/AGSSettings.cs
+++ b/AGS_oM/AGSSettings.cs
@@ -36,11 +36,15 @@ namespace BH.oM.Adapters.AGS
         /****            Public Properties              ****/
         /***************************************************/
 
-        [Description("If blank geology occurs in the GEOL_GEOL columns, assign a geology to replace it e.g. Made ground.")]
+        [Description("Only implemented when the BlankGeologyStrategy is set to replacement. \n" +
+            "If blank geology occurs in the GEOL_GEOL columns, assign a geology to replace it e.g. Made ground.")]
         public virtual string BlankGeology { get; set; }
 
-        /***************************************************/
-    }
+        [Description("The strategy used to handle blank geology entries.")]
+        public virtual BlankGeologyStrategy BlankGeologyStraegy { get; set; }
+
+    /***************************************************/
+}
 }
 
 

--- a/AGS_oM/AGS_oM.csproj
+++ b/AGS_oM/AGS_oM.csproj
@@ -9,7 +9,7 @@
     <Authors>BHoM</Authors>
     <Copyright>Copyright © https://github.com/BHoM</Copyright>
     <RootNamespace>BH.oM.AGS</RootNamespace>
-    <FileVersion>7.0.0.0</FileVersion>
+    <FileVersion>7.2.0.0</FileVersion>
 	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/AGS_oM/AGS_oM.csproj
+++ b/AGS_oM/AGS_oM.csproj
@@ -9,7 +9,7 @@
     <Authors>BHoM</Authors>
     <Copyright>Copyright © https://github.com/BHoM</Copyright>
     <RootNamespace>BH.oM.AGS</RootNamespace>
-    <FileVersion>7.2.0.0</FileVersion>
+    <FileVersion>7.3.0.0</FileVersion>
 	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/AGS_oM/eNums/BlankGeologyStrategy.cs
+++ b/AGS_oM/eNums/BlankGeologyStrategy.cs
@@ -20,50 +20,32 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.Engine.Base;
-using BH.oM.Adapter;
-using BH.oM.Base;
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using BH.oM.Ground;
-using BH.oM.Adapters.AGS;
+using BH.oM.Adapter;
+using BH.oM.Base.Attributes;
 
-namespace BH.Adapter.AGS
+namespace BH.oM.Adapters.AGS
 {
-    public partial class AGSAdapter
+    [Description("Different approaches for the AGS_Toolkit to handle blank geology.")]
+    public enum BlankGeologyStrategy
     {
-        /***************************************************/
-        /**** Private Methods                           ****/
-        /***************************************************/
-
-        private List<Stratum> ReadStrata(List<string> ids = null)
-        {
-            string groupKey = "GEOL";
-
-            if (!m_Data.ContainsKey(groupKey))
-            {
-                Compute.RecordError($"No data regarding boreholes was found in the file ({groupKey} group).");
-                return new List<Stratum>();
-            }
-
-            if (!m_Units.ContainsKey(groupKey))
-            {
-                Compute.RecordError($"No units regarding boreholes was found in the file ({groupKey} group).");
-                return new List<Stratum>();
-            }
-
-            BlankGeologyStrategy blankGeologyStrategy = m_Settings.BlankGeologyStraegy;
-            
-            return m_Data[groupKey].Select(data => Convert.FromStratum(data, m_Units[groupKey], m_blankGeology, blankGeologyStrategy)).Where(strata => strata != null).ToList();
-        }
-
-        /***************************************************/
-
+        [Description("Replace any entries of blank geology with a specificed string.")]
+        Replace = 0,
+        [Description("Replace any entries of blank geology using the description attribute (GEOL_DESC) with words in CAPS.")]
+        Description = 1,
+        [Description("Replace any entries of blank geology using the legend (GEOL_LEG).")]
+        Legend = 2,
+        [Description("Replace any entries of blank geology using the lexicon code (GEOL_BGS).")]
+        Lexicon = 3,
     }
 }
+
+
+
 
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Engine/pull/3375

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #12 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:x:/s/BHoM/EYiWcAMZ_jFAl782pP6Pgv8BAGorGhyPFzg3r_3PD6p_ew?e=K8CPRI

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added `BlankGeologyStrategy` that lets the user select different methods for handling empty GEOL_GEOL fields;
- The `Replace` will replace the blank field with a specific string;
- The `Lexicon` will replace the blank field with the lexicon code (if not empty);
- The `Legend` will replace the blank field with the legend code (if not empty);
- The `Description` will replace the blank field with the capitalised words in the description;

### Additional comments
<!-- As required -->
This will need to wait for the BHoM_Engine PR to be merged first as the branches are different names.