### PR TITLE
Store text in qualifier if it's not empty

### DIFF
--- a/AGS_Adapter/Convert/FromAGS/ContaminantSample.cs
+++ b/AGS_Adapter/Convert/FromAGS/ContaminantSample.cs
@@ -58,8 +58,8 @@ namespace BH.Adapter.AGS
             string type = GetString(data, "SAMP_TYPE");
             string rvalUnit = GetString(data, "ERES_RUNI");
 
-            //Replace the ERES_RVAL unit value, as this is provided in the ERES_RUNI column (not the UNITS heading)
-            units["ERES_RVAL"] = rvalUnit;
+            //Replace the ERES_RTXT unit value, as this is provided in the ERES_RUNI column (not the UNITS heading)
+            units["ERES_RTXT"] = rvalUnit;
             Type quantity = Convert.Quantity(rvalUnit);
             double result = GetDouble(data, units, "ERES_RTXT");
 

--- a/AGS_Adapter/Convert/FromAGS/ContaminantSample.cs
+++ b/AGS_Adapter/Convert/FromAGS/ContaminantSample.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BH.Engine.Base;
 using BH.oM.Ground;
 
 namespace BH.Adapter.AGS
@@ -61,6 +62,11 @@ namespace BH.Adapter.AGS
             units["ERES_RVAL"] = rvalUnit;
             Type quantity = Convert.Quantity(rvalUnit);
             double result = GetDouble(data, units, "ERES_RTXT");
+
+            string rTxt = "";
+            // Essentially if there was text in the ERES_RTXT that is not < or >, then add it to the qualifier
+            if (double.IsNaN(result))
+                rTxt = GetString(data, "ERES_RTXT");
 
             List<IContaminantProperty> contaminantProperties = new List<IContaminantProperty>();
 
@@ -136,7 +142,14 @@ namespace BH.Adapter.AGS
 
             // Result Properties
             string resultType = GetString(data, "ERES_RTCD");
+
             string interpretedQualifier = GetString(data, "ERES_IQLF");
+
+            if (rTxt != "" && interpretedQualifier != "")
+                Compute.RecordWarning("The qualifier contains data and cannot be overwritten.");
+            else if (rTxt != "" && interpretedQualifier == "")
+                interpretedQualifier = rTxt;
+
             bool reportable = GetBool(data, "ERES_RRES");
             bool detectFlag = GetBool(data, "ERES_DETF");
             bool organic = GetBool(data, "ERES_ORG");

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,3 +1,4 @@
 BHoM/BHoM
 BHoM/BHoM_Engine
 BHoM/BHoM_Adapter
+BHoM/Localisation_Toolkit


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #20 
Closes #22 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/EXTqPS5noR9FkHJcowtmoksBKTdIQzZ4wiNxv1koKKiMow?e=aDQDEE

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Store text such as "No Abestos Detected" in `InterpretedQualifier` field as it's useful for post processing;
- Fixed a bug whereby the units for the `ContaminantSample` was not being properly captured.

### Additional comments
<!-- As required -->
