### PR TITLE
Ensure observedGeology is correctly assigned when Description is used

### DIFF
--- a/AGS_Adapter/Convert/FromAGS/Stratum.cs
+++ b/AGS_Adapter/Convert/FromAGS/Stratum.cs
@@ -101,7 +101,7 @@ namespace BH.Adapter.AGS
                                 //Remove punctuation and numbers
                                 string upperWords = String.Join(" ", description.Split(' ').Where(x => string.Equals(x, x.ToUpper(), StringComparison.Ordinal)));
                                 upperWords = string.Concat(upperWords.Where(char.IsLetter));
-                                blankGeology = upperWords.Trim();
+                                observedGeology = upperWords.Trim();
                             }
                             else
                                 Engine.Base.Compute.RecordWarning($"No description provided for {id}. Therefore, the blank geology cannot be set.");


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #28 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:x:/s/BHoM/EYiWcAMZ_jFAl782pP6Pgv8BAGorGhyPFzg3r_3PD6p_ew?e=K8CPRI

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed a bug whereby if the `Description` option was used in `AGSSettings` it would not update the `ObservedGeology`.

### Additional comments
<!-- As required -->
