### PR TITLE
Add read functionality for InSituVane tests

### DIFF
--- a/AGS_Adapter/CRUD/Read/Boreholes.cs
+++ b/AGS_Adapter/CRUD/Read/Boreholes.cs
@@ -58,7 +58,7 @@ namespace BH.Adapter.AGS
 
             List<Stratum> strata = ReadStrata();
             List<ContaminantSample> contaminantSamples = ReadContaminantSamples();
-            List<InSituVane> inSituVanes = ReadInSituVane();
+            List<InSituVane> inSituVanes = ReadInSituVanes();
             return m_Data[groupKey].Select(data => Convert.FromBorehole(data, m_Units[groupKey], strata, contaminantSamples, inSituVanes)).Where(borehole => borehole != null).ToList();
         }
 

--- a/AGS_Adapter/CRUD/Read/InSituVane.cs
+++ b/AGS_Adapter/CRUD/Read/InSituVane.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter.AGS
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private List<InSituVane> ReadInSituVane(List<string> ids = null)
+        private List<InSituVane> ReadInSituVanes(List<string> ids = null)
         {
             string groupKey = "IVAN";
 

--- a/AGS_Adapter/CRUD/Read/InSituVane.cs
+++ b/AGS_Adapter/CRUD/Read/InSituVane.cs
@@ -30,8 +30,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Ground;
-using BH.Engine.Data;
-
 
 namespace BH.Adapter.AGS
 {
@@ -40,26 +38,24 @@ namespace BH.Adapter.AGS
         /***************************************************/
         /**** Private Methods                           ****/
         /***************************************************/
-        private List<Borehole> ReadBoreholes(List<string> ids = null)
+
+        private List<InSituVane> ReadInSituVane(List<string> ids = null)
         {
-            string groupKey = "LOCA";
+            string groupKey = "IVAN";
 
             if (!m_Data.ContainsKey(groupKey))
             {
-                Engine.Base.Compute.RecordError($"No data regarding boreholes was found in the file ({groupKey} group).");
-                return new List<Borehole>();
+                Compute.RecordError($"No data regarding in situ vane samples were found in the file ({groupKey} group).");
+                return new List<InSituVane>();
             }
 
             if (!m_Units.ContainsKey(groupKey))
             {
-                Engine.Base.Compute.RecordError($"No units regarding boreholes was found in the file ({groupKey} group).");
-                return new List<Borehole>();
+                Compute.RecordError($"No units regarding boreholes was found in the file ({groupKey} group).");
+                return new List<InSituVane>();
             }
 
-            List<Stratum> strata = ReadStrata();
-            List<ContaminantSample> contaminantSamples = ReadContaminantSamples();
-            List<InSituVane> inSituVanes = ReadInSituVane();
-            return m_Data[groupKey].Select(data => Convert.FromBorehole(data, m_Units[groupKey], strata, contaminantSamples, inSituVanes)).Where(borehole => borehole != null).ToList();
+            return m_Data[groupKey].Select(data => Convert.FromInSituVane(data, m_Units[groupKey])).Where(test => test != null).ToList();
         }
 
         /***************************************************/

--- a/AGS_Adapter/CRUD/Read/_IRead.cs
+++ b/AGS_Adapter/CRUD/Read/_IRead.cs
@@ -48,6 +48,8 @@ namespace BH.Adapter.AGS
                 return ReadStrata();
             if (type == typeof(ContaminantSample))
                 return ReadContaminantSamples();
+            if (type == typeof(InSituVane))
+                return ReadInSituVane();
 
             return new List<IBHoMObject>();
         }

--- a/AGS_Adapter/CRUD/Read/_IRead.cs
+++ b/AGS_Adapter/CRUD/Read/_IRead.cs
@@ -49,7 +49,7 @@ namespace BH.Adapter.AGS
             if (type == typeof(ContaminantSample))
                 return ReadContaminantSamples();
             if (type == typeof(InSituVane))
-                return ReadInSituVane();
+                return ReadInSituVanes();
 
             return new List<IBHoMObject>();
         }

--- a/AGS_Adapter/Convert/FromAGS/Borehole.cs
+++ b/AGS_Adapter/Convert/FromAGS/Borehole.cs
@@ -41,7 +41,7 @@ namespace BH.Adapter.AGS
         /***************************************************/
 
         public static Borehole FromBorehole(Dictionary<string, string> data, Dictionary<string, string> units, List<Stratum> strata,
-            List<ContaminantSample> contaminantSamples, List<InSituVane>inSituVanes)
+            List<ContaminantSample> contaminantSamples, List<InSituVane> inSituVanes)
         {
             string id = GetString(data, "LOCA_ID");
 
@@ -146,6 +146,17 @@ namespace BH.Adapter.AGS
                 boreholeProperties.Add(boreholeReference);
 
             Borehole borehole = Engine.Ground.Create.Borehole(id, top, bottom, null, boreholeProperties, boreholeStrata, boreholeContaminants);
+
+            Borehole borehole1 = new Borehole()
+            {
+                Id = id,
+                Top = top,
+                Bottom = bottom,
+                BoreholeProperties = boreholeProperties,
+                Strata = boreholeStrata,
+                ContaminantSamples = boreholeContaminants,
+                GeotechnicalTestResults = new List<ITest>(boreholeInSituVane)
+            };
 
             return borehole;
 

--- a/AGS_Adapter/Convert/FromAGS/Borehole.cs
+++ b/AGS_Adapter/Convert/FromAGS/Borehole.cs
@@ -145,9 +145,7 @@ namespace BH.Adapter.AGS
             if (boreholeReference != null)
                 boreholeProperties.Add(boreholeReference);
 
-            Borehole borehole = Engine.Ground.Create.Borehole(id, top, bottom, null, boreholeProperties, boreholeStrata, boreholeContaminants);
-
-            Borehole borehole1 = new Borehole()
+            Borehole borehole = new Borehole()
             {
                 Id = id,
                 Top = top,

--- a/AGS_Adapter/Convert/FromAGS/Borehole.cs
+++ b/AGS_Adapter/Convert/FromAGS/Borehole.cs
@@ -41,7 +41,7 @@ namespace BH.Adapter.AGS
         /***************************************************/
 
         public static Borehole FromBorehole(Dictionary<string, string> data, Dictionary<string, string> units, List<Stratum> strata,
-            List<ContaminantSample> contaminantSamples)
+            List<ContaminantSample> contaminantSamples, List<InSituVane>inSituVanes)
         {
             string id = GetString(data, "LOCA_ID");
 
@@ -95,6 +95,7 @@ namespace BH.Adapter.AGS
 
             List<Stratum> boreholeStrata = strata.Where(x => x.Id == id).ToList();
             List<ContaminantSample> boreholeContaminants = contaminantSamples.Where(x => x.Id == id).ToList();
+            List<InSituVane> boreholeInSituVane = inSituVanes.Where(x => x.Id == id).ToList();
 
             List<IBoreholeProperty> boreholeProperties = new List<IBoreholeProperty>();
 

--- a/AGS_Adapter/Convert/FromAGS/InSituVane.cs
+++ b/AGS_Adapter/Convert/FromAGS/InSituVane.cs
@@ -71,7 +71,7 @@ namespace BH.Adapter.AGS
 
             // InSituVane Test Properties
             string testReference = GetString(data, "IVAN_TESN");
-            string type = GetString(data, "IVAN_TYPE)");
+            string type = GetString(data, "IVAN_TYPE");
             string tester = GetString(data, "IVAN_CONT"); 
             string testMethod = GetString(data, "IVAN_METH");
             string accreditingBody = GetString(data, "IVAN_CRED");

--- a/AGS_Adapter/Convert/FromAGS/InSituVane.cs
+++ b/AGS_Adapter/Convert/FromAGS/InSituVane.cs
@@ -61,8 +61,8 @@ namespace BH.Adapter.AGS
             InSituVaneReferenceProperties InSituVaneReferenceProperties = new InSituVaneReferenceProperties() 
             { 
                 Details = details, 
-                Weather = weather, Date = testdate, 
-                StratumReference = stratumreference, 
+                Weather = weather, Date = testDate, 
+                StratumReference = stratumReference, 
                 FileReference = files 
             };
 
@@ -81,9 +81,9 @@ namespace BH.Adapter.AGS
             {
                 Reference = testReference,
                 Type = type,
-                Method = testmethod,
+                Method = testMethod,
                 Tester = tester,
-                AccreditingBody = accreditingbody,
+                AccreditingBody = accreditingBody,
                 Status = testStatus
             };
             
@@ -96,10 +96,10 @@ namespace BH.Adapter.AGS
 
             InSituVaneResultProperties inSituVaneResultProperties = new InSituVaneResultProperties()
             {
-                VaneResidualResult = vaneresidualresult
+                VaneResidualResult = vaneResidualResult
             };
-            if (InSituVaneResultProperties != null)
-                testProperties.Add(InSituVaneResultProperties);
+            if (inSituVaneResultProperties != null)
+                testProperties.Add(inSituVaneResultProperties);
 
             InSituVane inSituVane = new InSituVane
             {

--- a/AGS_Adapter/Convert/FromAGS/InSituVane.cs
+++ b/AGS_Adapter/Convert/FromAGS/InSituVane.cs
@@ -86,6 +86,7 @@ namespace BH.Adapter.AGS
                 AccreditingBody = accreditingbody,
                 Status = testStatus
             };
+            
             if (InSituVaneTestProperties != null)
                 testProperties.Add(InSituVaneTestProperties);
 

--- a/AGS_Adapter/Convert/FromAGS/InSituVane.cs
+++ b/AGS_Adapter/Convert/FromAGS/InSituVane.cs
@@ -94,7 +94,7 @@ namespace BH.Adapter.AGS
             double vaneResidualResult = GetDouble(data, units, "IVAN_IVAR");
 
 
-            InSituVaneResultProperties InSituVaneResultProperties = new InSituVaneResultProperties()
+            InSituVaneResultProperties inSituVaneResultProperties = new InSituVaneResultProperties()
             {
                 VaneResidualResult = vaneresidualresult
             };

--- a/AGS_Adapter/Convert/FromAGS/InSituVane.cs
+++ b/AGS_Adapter/Convert/FromAGS/InSituVane.cs
@@ -73,8 +73,8 @@ namespace BH.Adapter.AGS
             string testReference = GetString(data, "IVAN_TESN");
             string type = GetString(data, "IVAN_TYPE)");
             string tester = GetString(data, "IVAN_CONT"); 
-            string testmethod = GetString(data, "IVAN_METH");
-            string accreditingbody = GetString(data, "IVAN_CRED");
+            string testMethod = GetString(data, "IVAN_METH");
+            string accreditingBody = GetString(data, "IVAN_CRED");
             string testStatus = GetString(data, "TEST_STAT");
 
             InSituVaneTestProperties InSituVaneTestProperties = new InSituVaneTestProperties()

--- a/AGS_Adapter/Convert/FromAGS/InSituVane.cs
+++ b/AGS_Adapter/Convert/FromAGS/InSituVane.cs
@@ -91,7 +91,7 @@ namespace BH.Adapter.AGS
                 testProperties.Add(InSituVaneTestProperties);
 
             // InSituVane Result Properties
-            double vaneresidualresult = GetDouble(data, units, "IVAN_IVAR");
+            double vaneResidualResult = GetDouble(data, units, "IVAN_IVAR");
 
 
             InSituVaneResultProperties InSituVaneResultProperties = new InSituVaneResultProperties()

--- a/AGS_Adapter/Convert/FromAGS/InSituVane.cs
+++ b/AGS_Adapter/Convert/FromAGS/InSituVane.cs
@@ -54,8 +54,8 @@ namespace BH.Adapter.AGS
             // InSituVane Reference
             string details = GetString(data, "IVAN_REM");
             string weather = GetString(data, "IVAN_ENV");
-            DateTime testdate = GetDateTime(data, units, "IVAN_DATE");
-            string stratumreference = GetString(data, "GEOL_STAT");
+            DateTime testDate = GetDateTime(data, units, "IVAN_DATE");
+            string stratumReference = GetString(data, "GEOL_STAT");
             string files = GetString(data, "FILE_FSET");
 
             InSituVaneReferenceProperties InSituVaneReferenceProperties = new InSituVaneReferenceProperties() 

--- a/AGS_Adapter/Convert/FromAGS/InSituVane.cs
+++ b/AGS_Adapter/Convert/FromAGS/InSituVane.cs
@@ -1,0 +1,114 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.Engine.Base;
+using BH.oM.Ground;
+
+namespace BH.Adapter.AGS
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+        public static InSituVane FromInSituVane(Dictionary<string, string> data, Dictionary<string, string> units)
+        {
+            string id = GetString(data, "LOCA_ID");
+
+            double top = GetDouble(data, units, "IVAN_DPTH");
+
+            if (double.IsNaN(top))
+            {
+                if (id == "")
+                    Compute.RecordWarning($"The top (IVAN_DPTH) value for {id} is invalid and has been skipped.");
+            }
+
+            double result = GetDouble(data, units, "IVAN_IVAN");
+
+            List<ITestProperties> testProperties = new List<ITestProperties>();
+
+            // InSituVane Reference
+            string details = GetString(data, "IVAN_REM");
+            string weather = GetString(data, "IVAN_ENV");
+            DateTime testdate = GetDateTime(data, units, "IVAN_DATE");
+            string stratumreference = GetString(data, "GEOL_STAT");
+            string files = GetString(data, "FILE_FSET");
+
+            InSituVaneReferenceProperties InSituVaneReferenceProperties = new InSituVaneReferenceProperties() { Details = details, Weather = weather, Date = testdate, StratumReference = stratumreference, FileReference = files };
+            if (InSituVaneReferenceProperties != null)
+                testProperties.Add(InSituVaneReferenceProperties);
+
+            // InSituVane Test Properties
+            string testReference = GetString(data, "IVAN_TESN");
+            string type = GetString(data, "IVAN_TYPE)");
+            string tester = GetString(data, "IVAN_CONT"); 
+            string testmethod = GetString(data, "IVAN_METH");
+            string accreditingbody = GetString(data, "IVAN_CRED");
+            string testStatus = GetString(data, "TEST_STAT");
+
+            InSituVaneTestProperties InSituVaneTestProperties = new InSituVaneTestProperties()
+            {
+                Reference = testReference,
+                Type = type,
+                Method = testmethod,
+                Tester = tester,
+                AccreditingBody = accreditingbody,
+                Status = testStatus
+            };
+            if (InSituVaneTestProperties != null)
+                testProperties.Add(InSituVaneTestProperties);
+
+            // InSituVane Result Properties
+            double vaneresidualresult = GetDouble(data, units, "IVAN_IVAR");
+
+
+            InSituVaneResultProperties InSituVaneResultProperties = new InSituVaneResultProperties()
+            {
+                VaneResidualResult = vaneresidualresult
+            };
+            if (InSituVaneResultProperties != null)
+                testProperties.Add(InSituVaneResultProperties);
+
+            InSituVane inSituVane = new InSituVane
+            {
+                Id = id,
+                Top = top,
+                Result=result,
+                Properties = testProperties,
+            };
+
+            return inSituVane;
+
+        }
+
+        /***************************************************/
+
+    }
+}
+
+
+

--- a/AGS_Adapter/Convert/FromAGS/InSituVane.cs
+++ b/AGS_Adapter/Convert/FromAGS/InSituVane.cs
@@ -58,7 +58,14 @@ namespace BH.Adapter.AGS
             string stratumreference = GetString(data, "GEOL_STAT");
             string files = GetString(data, "FILE_FSET");
 
-            InSituVaneReferenceProperties InSituVaneReferenceProperties = new InSituVaneReferenceProperties() { Details = details, Weather = weather, Date = testdate, StratumReference = stratumreference, FileReference = files };
+            InSituVaneReferenceProperties InSituVaneReferenceProperties = new InSituVaneReferenceProperties() 
+            { 
+                Details = details, 
+                Weather = weather, Date = testdate, 
+                StratumReference = stratumreference, 
+                FileReference = files 
+            };
+
             if (InSituVaneReferenceProperties != null)
                 testProperties.Add(InSituVaneReferenceProperties);
 

--- a/AGS_Adapter/Convert/Units/Quantity.cs
+++ b/AGS_Adapter/Convert/Units/Quantity.cs
@@ -37,10 +37,10 @@ namespace BH.Adapter.AGS
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static Type Quantity(string unit, string key = "")
+        public static Type Quantity(string quantity, string key = "")
         {
 
-            switch (Regex.Replace(unit, @"\s+", "").ToLower())
+            switch (Regex.Replace(quantity, @"\s+", "").ToLower())
             {
                 // Length
                 case "m":
@@ -104,9 +104,10 @@ namespace BH.Adapter.AGS
                 case "no":
                 case "nounits":
                 case "none":
+                case "type":
                     return null;
                 default:
-                    Compute.RecordWarning($"Unit \"{unit}\" not recognised, no quantity has been assigned.");
+                    Compute.RecordWarning($"Quantity \"{quantity}\" not recognised, no quantity has been assigned.");
                     return null;
 
             }

--- a/AGS_Adapter/Convert/Units/Units.cs
+++ b/AGS_Adapter/Convert/Units/Units.cs
@@ -107,9 +107,7 @@ namespace BH.Adapter.AGS
                 case "ms/cm":
                     return value.FromSiemensPerCentimetre() * Math.Pow(10, -3); ;
                 // Pressure
-                case "kPa":
                 case "kpa":
-                case "KPA":
                     return value.FromKilonewtonPerSquareMetre();
                 // Dimensionless
                 case "%":

--- a/AGS_Adapter/Convert/Units/Units.cs
+++ b/AGS_Adapter/Convert/Units/Units.cs
@@ -106,6 +106,11 @@ namespace BH.Adapter.AGS
                     return value.FromSiemensPerCentimetre()*Math.Pow(10,-6);
                 case "ms/cm":
                     return value.FromSiemensPerCentimetre() * Math.Pow(10, -3); ;
+                // Pressure
+                case "kPa":
+                case "kpa":
+                case "KPA":
+                    return value.FromKilonewtonPerSquareMetre();
                 // Dimensionless
                 case "%":
                 case "%w/w":

--- a/AGS_Adapter/Convert/Units/Units.cs
+++ b/AGS_Adapter/Convert/Units/Units.cs
@@ -123,6 +123,7 @@ namespace BH.Adapter.AGS
                 case "no":
                 case "nounits":
                 case "none":
+                case "type":
                     return value;
                 default:
                     Compute.RecordWarning($"Unit \"{unit}\" not recognised, no unit conversion has occured for {key}.");

--- a/AGS_Adapter/PrivateHelpers/GetDateTime.cs
+++ b/AGS_Adapter/PrivateHelpers/GetDateTime.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using BH.Engine.Base;
 
 namespace BH.Adapter.AGS
@@ -61,6 +62,7 @@ namespace BH.Adapter.AGS
             }
             else
             {
+                format = Regex.Replace(format, @"(?<!M)m{2}(?!m)", "MM"); // this is to ensure mm becomes MM (mm format is for minutes)
                 if (!DateTime.TryParseExact(text, format, CultureInfo.InvariantCulture, DateTimeStyles.None, out date))
                     date = default(DateTime);
             }


### PR DESCRIPTION
### Issues addressed by this PR
https://github.com/BHoM/AGS_Toolkit/issues/33
Addresses issue 33, adding read and convert capabilities for In Situ Vane data from AGS files.

See also
https://github.com/BHoM/AGS_Toolkit/issues/26
https://github.com/BHoM/BHoM/issues/1640
https://github.com/BHoM/BHoM_Engine/issues/3418



### Test files
Grasshopper:
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/AGS_Toolkit/%2333-addinsituvanereadtests/37367%20-%202023-08-08%201339%20-%20Final%20-%202.ags?csf=1&web=1&e=IiVlCW


### Changelog
- Added bug fix for date formats that are yyyy-mm-dd as C# would parse the mm as minutes instead of months;
- Added real functionality for `InSituVaneTests` and all associated properties.

